### PR TITLE
Disable highlighting the slider's wrapper

### DIFF
--- a/lightSlider/css/lightSlider.css
+++ b/lightSlider/css/lightSlider.css
@@ -2,6 +2,12 @@
 
 .lSSlideOuter {
 	overflow: hidden;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 .lightSlider:before, .lightSlider:after {
 	content: " ";


### PR DESCRIPTION
When you click the arrows sometimes the whole carousel wrapper gets highlighted. This simple fix disables highlighting the whole wrapper for the carousel.
