### PR TITLE
Removing explicit height on lslide classes

### DIFF
--- a/lightSlider/js/jquery.lightSlider.js
+++ b/lightSlider/js/jquery.lightSlider.js
@@ -440,7 +440,6 @@
                         tP = ((tHT) * 100) / elSize;
                     }
                     ob.css({
-                        'height': tH + 'px',
                         'padding-bottom': tP + '%'
                     });
                 };


### PR DESCRIPTION
When resizing a horizontal lightSlider gallery, I was getting a large amount of unnecessary vertical space between the gallery image and the thumbnails. It's possible that I just coded it wrong. Removing this one line fixed it, though.

Try out this change locally first and see if it breaks/improves anything on your end.
