### PR TITLE
Remove folder "demo" from sources if installing with Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
   ],
   "license": "MLT",
   "ignore": [
-    "README.md"
+    "README.md",
+    "demo"
   ]
 }


### PR DESCRIPTION
Usually coders don't need "demo" in sources if they install package with Bower
