### PR TITLE
Ignore keyobard nav when focus is in textarea or input

### DIFF
--- a/lightSlider/js/jquery.lightSlider.js
+++ b/lightSlider/js/jquery.lightSlider.js
@@ -168,6 +168,7 @@
             keyPress: function () {
                 if (settings.keyPress) {
                     $(document).on('keyup.lightslider', function (e) {
+                      if (!$(':focus').is('input, textarea')) {
                         e.preventDefault();
                         if (e.keyCode === 37) {
                             $el.goToPrevSlide();
@@ -176,6 +177,7 @@
                             $el.goToNextSlide();
                             clearInterval(interval);
                         }
+                      }
                     });
                 }
             },
@@ -421,7 +423,7 @@
                     $slide.parent().find('.lSPager').css(gMargin, settings.galleryMargin + 'px');
                     refresh.createPager();
                 }
-                
+
                 setTimeout(function () {
                     refresh.init();
                 }, 0);


### PR DESCRIPTION
Thanks very much for the lightslider plugin.

I've run into an issue with the keyboard navigation. If a text area or input is on the same page as the slideshow, the keyboard navigation continues to function when they are navigating through the text area with the forward and back arrows.

I thought you might like to consider this PR.