### PR TITLE
Hidden slides shouldn't affect slider width

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -41,7 +41,7 @@
             <li>
                 <h3>1</h3>
             </li>
-            <li>
+            <li style="display: none;">
                 <h3>2</h3>
             </li>
             <li>

--- a/demo/lightSlider/js/jquery.lightSlider.js
+++ b/demo/lightSlider/js/jquery.lightSlider.js
@@ -71,7 +71,7 @@
         if (settings.mode === 'fade') {
             settings.vertical = false;
         }
-        var $children = $el.children(),
+        var $children = $el.children().filter(':visible'),
             windowW = $(window).width(),
             breakpoint = null,
             resposiveObj = null,
@@ -140,9 +140,9 @@
                 w = ln * (slideWidth + settings.slideMargin);
             } else {
                 w = 0;
-                for (var i = 0; i < ln; i++) {
-                    w += (parseInt($children.eq(i).width()) + settings.slideMargin);
-                }
+                $children.each(function(){
+                    w += (parseInt($(this).width()) + settings.slideMargin);
+                });
             }
             if (w % 1 !== 0) {
                 w = w + 1;
@@ -199,6 +199,7 @@
                             $el.goToNextSlide();
                         }
                         clearInterval(interval);
+                        return false;
                     });
                 }
             },
@@ -298,7 +299,7 @@
                     }
                 };
                 refresh.calL = function () {
-                    $children = $el.children();
+                    $children = $el.children().filter(':visible');
                     length = $children.length;
                 };
                 if (this.doCss()) {
@@ -349,16 +350,16 @@
                         }
                         var thumb = $children.eq(i * settings.slideMove).attr('data-thumb');
                         if (settings.gallery === true) {
-                            pagers += '<li style="width:100%;' + property + ':' + thumbWidth + 'px;' + gutter + ':' + settings.thumbMargin + 'px"><a href="javascript:void(0)"><img src="' + thumb + '" /></a></li>';
+                            pagers += '<li style="width:100%;' + property + ':' + thumbWidth + 'px;' + gutter + ':' + settings.thumbMargin + 'px"><a href="#"><img src="' + thumb + '" /></a></li>';
                         } else {
-                            pagers += '<li><a href="javascript:void(0)">' + (i + 1) + '</a></li>';
+                            pagers += '<li><a href="#">' + (i + 1) + '</a></li>';
                         }
                         if (settings.mode === 'slide') {
                             if ((v) >= w - elSize - settings.slideMargin) {
                                 i = i + 1;
                                 var minPgr = 2;
                                 if (settings.autoWidth) {
-                                    pagers += '<li><a href="javascript:void(0)">' + (i + 1) + '</a></li>';
+                                    pagers += '<li><a href="#">' + (i + 1) + '</a></li>';
                                     minPgr = 1;
                                 }
                                 if (i < minPgr) {
@@ -407,6 +408,7 @@
                             $this.slideThumb();
                         }
                         clearInterval(interval);
+                        return false;
                     });
                 };
                 if (settings.pager) {

--- a/lightSlider/js/jquery.lightSlider.js
+++ b/lightSlider/js/jquery.lightSlider.js
@@ -71,7 +71,7 @@
         if (settings.mode === 'fade') {
             settings.vertical = false;
         }
-        var $children = $el.children(),
+        var $children = $el.children().filter(':visible'),
             windowW = $(window).width(),
             breakpoint = null,
             resposiveObj = null,
@@ -140,9 +140,9 @@
                 w = ln * (slideWidth + settings.slideMargin);
             } else {
                 w = 0;
-                for (var i = 0; i < ln; i++) {
-                    w += (parseInt($children.eq(i).width()) + settings.slideMargin);
-                }
+                $children.each(function(){
+                    w += (parseInt($(this).width()) + settings.slideMargin);
+                });
             }
             if (w % 1 !== 0) {
                 w = w + 1;
@@ -299,7 +299,7 @@
                     }
                 };
                 refresh.calL = function () {
-                    $children = $el.children();
+                    $children = $el.children().filter(':visible');
                     length = $children.length;
                 };
                 if (this.doCss()) {


### PR DESCRIPTION
Hi, I really appreciate your work. I'm using your plugin in my latest project but I found some issue during development. I've created a filter that shows and hides certain slides so I can show only some of them. But if I set `display: none;` to any of slide it's width still affects whole slider width. There can be other reasons someone wants to keep hidden slides so I've made subtle changes to force `lightslider` to work only with visible slides. Please take a look :)

P.S. I did quick test to check if it still works well in `slide` mode and it seems it does!

Regards,
Marcin