### PR TITLE
Images sometimes disappear or move to the incorrect slide

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -268,9 +268,11 @@
                                 }
                             }
                             /**/
-                            for (var n = $el.find('.clone.right').length; n < tItem; n++) {
-                                $el.find('.lslide').eq(n).clone().removeClass('lslide').addClass('clone right').appendTo($el);
-                                scene++;
+                            if($el.find('.clone.right').length > 0){
+                                for (var n = $el.find('.clone.right').length; n < tItem; n++) {
+                                    $el.find('.lslide').eq(n).clone().removeClass('lslide').addClass('clone right').appendTo($el);
+                                    scene++;
+                                }
                             }
                             for (var m = $el.find('.lslide').length - $el.find('.clone.left').length; m > ($el.find('.lslide').length - tItem); m--) {
                                 $el.find('.lslide').eq(m - 1).clone().removeClass('lslide').addClass('clone left').prependTo($el);
@@ -571,7 +573,7 @@
                         }
                         $this.move($el, slideValue);
                         if (settings.loop === true && settings.mode === 'slide') {
-                            if (scene >= (length - ($el.find('.clone.left').length / settings.slideMove))) {
+                            if (scene > (length - ($el.find('.clone.left').length / settings.slideMove))) {
                                 $this.resetSlide($el.find('.clone.left').length);
                             }
                             if (scene === 0) {
@@ -590,7 +592,7 @@
                     $slide.css('transition-duration', '0ms');
                     slideValue = $this.slideValue();
                     $this.active($children, false);
-                    plugin.move($el, slideValue);
+                    plugin.move($el, scene);
                     setTimeout(function () {
                         $slide.css('transition-duration', settings.speed + 'ms');
                         $slide.find('.lSAction a').removeClass('disabled');


### PR DESCRIPTION
When the slider only shows one image and the window is resized, the image sometimes disappears. This is caused by incorrectly choosing the element to obtain the size from.

When including a fix for selecting the correct image (see PR) and the slider shows multiple images, selecting the last image sometimes labels the first image as active when using the loop setting.

See PR for fixes.