### PR TITLE
jquery v3.1 compatibility

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -453,7 +453,7 @@
                             $this.auto();
                         }   
                     }else{
-                        obj.find('img').load(function () {
+                        obj.find('img').on('load', function () {
                             setTimeout(function () {
                                 setCss();
                                 if (!interval) {

--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -453,7 +453,7 @@
                             $this.auto();
                         }   
                     }else{
-                        obj.find('img').on('load', function () {
+                        obj.find('img').load(function () {
                             setTimeout(function () {
                                 setCss();
                                 if (!interval) {


### PR DESCRIPTION
Since jQuery 3 `.load` event listener has been deprecated. More details: https://blog.jquery.com/
