### PR TITLE
improve width calculation (autoWidth option true)

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -141,10 +141,10 @@
             } else {
                 w = 0;
                 for (var i = 0; i < ln; i++) {
-                    w += (parseInt($children.eq(i).width()) + settings.slideMargin);
+                    w += ($children.eq(i)[0].getBoundingClientRect().width + settings.slideMargin);
                 }
             }
-            return w;
+            return Math.ceil(w);
         };
         plugin = {
             doCss: function () {


### PR DESCRIPTION
Fix issue of missing last slide when option autoWidth is set 'true'.

The problem (last slide breaks into next line and is therefore invisible) shows in every browser but Chrome and has its origin in the rounding of width values (function width() returns rounded value). My approach is to add up the exact widths of all slides and then round up the result, making sure enough space is available.