### PR TITLE
  Fix multiple sliders issue.

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -226,7 +226,9 @@
                 }
                 settings.onBeforeStart.call(this, $el);
                 refresh.chbreakpoint();
-                $el.addClass('lightSlider').wrap('<div class="lSSlideOuter ' + settings.addClass + '"><div class="lSSlideWrapper"></div></div>');
+                if (!$el.addClass('lightSlider').parents('.lSSlideOuter').length) {
+                    $el.addClass('lightSlider').wrap('<div class="lSSlideOuter ' + settings.addClass + '"><div class="lSSlideWrapper"></div></div>');
+                }
                 $slide = $el.parent('.lSSlideWrapper');
                 if (settings.rtl === true) {
                     $slide.parent().addClass('lSrtl');


### PR DESCRIPTION
  Multiple sliders on the same page is not working as expected. I have
  three tabs on my page and under each tab I have different slider with
  different id. I initialized each slider saperately, also I
  re-initialize the slider on tab click. so in this case I am facing a
  problem, the wrapper element with the class "lSSlideWrapper" is
  created on each tab click like:
 ```<div class="lSSlideOuter">
	<div class="lSSlideWrapper usingCss">
		<div class="lSSlideOuter">
			<div class="lSSlideWrapper usingCss">
				...........
			</div>
		</div>
	</div>
  </div>```