### PR TITLE
Window blur event

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ add the Following code to the &lt;head&gt; of your document.
             enableDrag:true,
             freeMove:true,
             swipeThreshold: 40,
+            freezeOnTabSwitch : false,
 
             responsive : [],
 

--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -36,6 +36,7 @@
         freeMove: true,
         swipeThreshold: 40,
         responsive: [],
+        freezeOnTabSwitch : false,
         /* jshint ignore:start */
         onBeforeStart: function ($el) {},
         onSliderLoad: function ($el) {},
@@ -874,13 +875,15 @@
                     }
                 }
 
-                $(window).on('focus', function(){
-                    $this.auto();
-                });
-                
-                $(window).on('blur', function(){
-                    clearInterval(interval);
-                });
+                if(settings.freezeOnTabSwitch){
+                    $(window).on('focus', function(){
+                        $this.auto();
+                    });
+                    
+                    $(window).on('blur', function(){
+                        clearInterval(interval);
+                    });
+                }
 
                 $this.pager();
                 $this.pauseOnHover();


### PR DESCRIPTION
Slider freezes on tab switch. made it configurable from settings. Default is set to false, i.e. slider will not be freezed upon browser blur.
