### PR TITLE
use scrollHeight for height calculations

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -433,7 +433,7 @@
                     obj = ob.children().first();
                 }
                 var setCss = function () {
-                    var tH = obj.outerHeight(),
+                    var tH = obj.prop('scrollHeight'),
                         tP = 0,
                         tHT = tH;
                     if (fade) {


### PR DESCRIPTION
use scrollHeight property instead of visible height (outerHeight) for calculating the height of the slider to avoid cutted off elements when resizing the browser window