### PR TITLE
Accessibility improvement for photo gallery thumbnails

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -355,7 +355,9 @@
                         }
                         var thumb = $children.eq(i * settings.slideMove).attr('data-thumb');
                         if (settings.gallery === true) {
-                            pagers += '<li style="width:100%;' + property + ':' + thumbWidth + 'px;' + gutter + ':' + settings.thumbMargin + 'px"><a href="#"><img src="' + thumb + '" /></a></li>';
+                            var thumbAlt = $children.eq(i * settings.slideMove).find('img').attr('alt');
+                            var thumbAltMarkup = (typeof thumbAlt !== 'undefined') ? 'alt="' + thumbAlt + '"' : '';
+                            pagers += '<li style="width:100%;' + property + ':' + thumbWidth + 'px;' + gutter + ':' + settings.thumbMargin + 'px"><a href="#"><img src="' + thumb + '" ' + thumbAltMarkup + '/></a></li>';
                         } else {
                             pagers += '<li><a href="#">' + (i + 1) + '</a></li>';
                         }


### PR DESCRIPTION
This fixes the issue brought up in https://github.com/sachinchoolur/lightslider/issues/310 about image thumbnails not having alt tags in a gallery.  This is an accessibility issue under 2.4.4 Link Purpose (In Context) – [ Level A ].  In my commit, I am gettin g the alt from the slide's alt.