### PR TITLE
fix js intervention error on vertical scroll

### DIFF
--- a/src/js/lightslider.js
+++ b/src/js/lightslider.js
@@ -839,9 +839,11 @@
                             $this.touchMove(endCoords.pageY, startCoords.pageY);
                         } else {
                             if ((xMovement * 3) > yMovement) {
-                                e.preventDefault();
+                                if(e.cancelable){
+                                    e.preventDefault();
+                                    $this.touchMove(endCoords.pageX, startCoords.pageX);
+                                }
                             }
-                            $this.touchMove(endCoords.pageX, startCoords.pageX);
                         }
 
                     });


### PR DESCRIPTION
A fix to the "Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted." error

Related issue #430 #384 